### PR TITLE
chore: update axios

### DIFF
--- a/fastify-session-authentication/package.json
+++ b/fastify-session-authentication/package.json
@@ -16,7 +16,7 @@
     "fastify": "^4.2.1"
   },
   "devDependencies": {
-    "axios": "^0.27.2",
+    "axios": "^1.6.8",
     "fastify-cli": "^4.3.0",
     "tap": "^16.3.0"
   }


### PR DESCRIPTION
I've updated axios from 0.27.2 version to 1.6.8 version.
I think 0.27 have a security fail.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
