### PR TITLE
example: add React 18 streaming using reply.hijack

### DIFF
--- a/react-streaming/README.md
+++ b/react-streaming/README.md
@@ -1,0 +1,33 @@
+## React 18 Streaming Example
+
+React 18 introduces `renderToPipeableStream` for server-side streaming.  
+Fastify requires `reply.hijack()` to allow streaming  
+without prematurely locking headers or status codes.
+
+```js
+import Fastify from 'fastify'
+import React from 'react'
+import { renderToPipeableStream } from 'react-dom/server'
+
+const app = Fastify()
+
+app.get('/', async(req, reply) => {
+  reply.hijack()
+
+  const stream = renderToPipeableStream(
+    React.createElement('div', null, 'Hello from React streaming 👋'),
+    {
+      onShellReady() {
+        reply.raw.setHeader('Content-Type', 'text/html; charset=utf-8')
+        stream.pipe()
+      },
+      onError(err) {
+        reply.raw.statusCode = 500
+        console.error(err)
+      }
+    }
+  )
+})
+
+await app.listen({ port: 3000 })
+```

--- a/react-streaming/index.js
+++ b/react-streaming/index.js
@@ -1,0 +1,25 @@
+import Fastify from 'fastify'
+import React from 'react'
+import { renderToPipeableStream } from 'react-dom/server'
+
+const app = Fastify()
+
+app.get('/', (req, reply) => {
+  reply.hijack()
+
+  const stream = renderToPipeableStream(
+    React.createElement('div', null, 'Hello from React streaming 👋'),
+    {
+      onShellReady () {
+        reply.raw.setHeader('Content-Type', 'text/html; charset=utf-8')
+        stream.pipe(reply.raw)
+      },
+      onError (err) {
+        console.error(err)
+      }
+    }
+  )
+})
+
+await app.listen({ port: 3000 })
+console.log('Server running on http://localhost:3000')

--- a/react-streaming/package.json
+++ b/react-streaming/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-streaming",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "fastify": "^5.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}


### PR DESCRIPTION
This PR adds a React 18 server-side streaming example using Fastify. 
It demonstrates the correct use of `reply.hijack()` to stream React content 
without prematurely locking headers or status codes.

Instructions to run are included in the README.md file.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [✔️] documentation is changed or added
- [✔️ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
