### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Here a list of external projects that could be useful to find some tips and sugg
 PR are welcome! Consider that a project to be added to this repository needs to have:
 
 + A `README.md` file that explains the project itself
-  + consider to use some [mermaid graph](https://mermaidjs.github.io)
+  + consider to use some [mermaid graph](https://mermaid.ai/open-source/)
 + Prefer a readable code, instead of concise
 + Comments on code that explain some code if there are more difficult parts
 + At least one test that show how to test the main function of the project

--- a/typescript-decorators/README.md
+++ b/typescript-decorators/README.md
@@ -40,4 +40,4 @@ For more details take a look on [fastify-decorators] package.
 [typescript-decorators.ts]: ./src/typescript-decorators.ts
 [typescript config]: ./tsconfig.json
 [app.js]: ./bin/app.js
-[fastify-decorators]: https://npmjs.org/package/fastify-decorators
+[fastify-decorators]: https://www.npmjs.com/package/fastify-decorators


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71